### PR TITLE
Restore manual search for new items

### DIFF
--- a/Jellyfin.Plugin.IMVDb/ImvdbClient.cs
+++ b/Jellyfin.Plugin.IMVDb/ImvdbClient.cs
@@ -42,7 +42,7 @@ public class ImvdbClient : IImvdbClient
     {
         var queryValue = new StringBuilder();
         queryValue.Append(searchInfo.Name);
-        foreach (var artist in searchInfo.Artists)
+        foreach (var artist in searchInfo.Artists ?? [])
         {
             queryValue.Append('+')
                 .Append(artist);


### PR DESCRIPTION
This PR fixes a `System.NullReferenceException` that occurs when searching for metadata.

According to the [TypeScript SDK](https://typescript-sdk.jellyfin.org/interfaces/generated-client.MusicVideoInfo.html), `MusicVideoInfo.Artists` is optional and can be `null`. This is the case for newly added items without metadata. In order to mitigate this, a fallback to an empty array is added.

Fixes #7